### PR TITLE
Fix typo in ad-behavior.md

### DIFF
--- a/doc_source/ad-behavior.md
+++ b/doc_source/ad-behavior.md
@@ -1,6 +1,6 @@
 # Understanding MediaTailor ad insertion behavior<a name="ad-behavior"></a>
 
-AWS Elemental MediaTailor stiches ads into live or video on demand \(VOD\) content by either replacing or inserting ads into the origin manifest\. Whether ads are inserted or replaced depends on how the ad breaks are configured in the origin manifest, and whether the content is VOD or live\.
+AWS Elemental MediaTailor stitches ads into live or video on demand \(VOD\) content by either replacing or inserting ads into the origin manifest\. Whether ads are inserted or replaced depends on how the ad breaks are configured in the origin manifest, and whether the content is VOD or live\.
 + With **ad replacement**, MediaTailor replaces content segments with ads\. 
 + With **ad insertion**, MediaTailor inserts ad content where segments don't exist\.
 


### PR DESCRIPTION
This PR corrects a typo in the `Understanding MediaTailor ad insertion behavior` document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
